### PR TITLE
Remove necessity of using config file in app

### DIFF
--- a/boilerplate/src/index.js
+++ b/boilerplate/src/index.js
@@ -1,12 +1,11 @@
-import Orchestrator, { ResponseHelper } from 'udes-node-orchestrator'
+import Orchestrator from 'udes-node-orchestrator'
 import config from './config'
 
-const getPostInfo = async (req, res) => {
-  const responseHelper = new ResponseHelper(req, res, config)
+const getPostInfo = async (responseHelper) => {
   const { post } = responseHelper.getQueryParameters()
   const options = {
     method: 'GET',
-    url: `${config.apiUrl}/posts/${post}`,
+    url: `/posts/${post}`,
   }
 
   try {

--- a/distribution/lib/ResponseHelper.js
+++ b/distribution/lib/ResponseHelper.js
@@ -170,7 +170,7 @@ var ResponseHelper = exports.ResponseHelper = function ResponseHelper(req, res, 
                   },
                   body: body && (typeof body === 'undefined' ? 'undefined' : _typeof(body)) === 'object' ? JSON.stringify(body) : body,
                   headers: headers,
-                  url: '' + _this.config.apiUrl + url
+                  url: /^.+:\/\//.test(url) ? url : '' + _this.config.apiUrl + url
                 });
 
                 if (opt.auth.pass) {
@@ -340,7 +340,7 @@ var ResponseHelper = exports.ResponseHelper = function ResponseHelper(req, res, 
                   pass: _this.req.session.cas.pt
                 },
                 headers: headers,
-                url: '' + _this.config.apiUrl + url
+                url: /^.+:\/\//.test(url) ? url : '' + _this.config.apiUrl + url
               });
 
               if (opt.auth.pass) {

--- a/distribution/lib/ResponseHelper.js
+++ b/distribution/lib/ResponseHelper.js
@@ -139,20 +139,6 @@ var logRequest = function logRequest(req, config, options) {
 };
 
 /**
- * Validate class constructor arguments.
- * @private
- * @param {Object} args - Arguments passed to class constructor.
- * @throws {Error} If an argument is null or undefined.
- */
-var checkArgs = function checkArgs(args) {
-  Object.keys(args).forEach(function (key) {
-    if (!args[key]) {
-      throw new Error('new ResponseHelper() - Missing argument ' + key);
-    }
-  });
-};
-
-/**
  * Handles response standardisation as well as http responses and requests.
  * @class
  * @param {Object} req - {@link https://expressjs.com/en/4x/api.html#req HTTP request}.
@@ -170,20 +156,21 @@ var ResponseHelper = exports.ResponseHelper = function ResponseHelper(req, res, 
     var retry = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
     return new Promise(function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(resolve, reject) {
-        var body, _options$headers, headers, opt, time;
+        var body, _options$headers, headers, url, opt, time;
 
         return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
-                body = options.body, _options$headers = options.headers, headers = _options$headers === undefined ? getHeaders() : _options$headers;
+                body = options.body, _options$headers = options.headers, headers = _options$headers === undefined ? getHeaders() : _options$headers, url = options.url;
                 opt = _extends({}, options, {
                   auth: {
                     user: _this.req.session.cas.user,
                     pass: _this.req.session.cas.pt
                   },
                   body: body && (typeof body === 'undefined' ? 'undefined' : _typeof(body)) === 'object' ? JSON.stringify(body) : body,
-                  headers: headers
+                  headers: headers,
+                  url: '' + _this.config.apiUrl + url
                 });
 
                 if (opt.auth.pass) {
@@ -340,19 +327,20 @@ var ResponseHelper = exports.ResponseHelper = function ResponseHelper(req, res, 
 
   this.getFile = function () {
     var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3(options) {
-      var _options$headers2, headers, opt;
+      var _options$headers2, headers, url, opt;
 
       return regeneratorRuntime.wrap(function _callee3$(_context3) {
         while (1) {
           switch (_context3.prev = _context3.next) {
             case 0:
-              _options$headers2 = options.headers, headers = _options$headers2 === undefined ? getHeaders() : _options$headers2;
+              _options$headers2 = options.headers, headers = _options$headers2 === undefined ? getHeaders() : _options$headers2, url = options.url;
               opt = _extends({}, options, {
                 auth: {
                   user: _this.req.session.cas.user,
                   pass: _this.req.session.cas.pt
                 },
-                headers: headers
+                headers: headers,
+                url: '' + _this.config.apiUrl + url
               });
 
               if (opt.auth.pass) {
@@ -450,7 +438,6 @@ var ResponseHelper = exports.ResponseHelper = function ResponseHelper(req, res, 
     _this.res.status(200).send(formatData ? formatResponse(_this.req, data) : data);
   };
 
-  checkArgs({ req: req, res: res, config: config });
   this.req = req;
   this.res = res;
   this.config = config;

--- a/distribution/lib/notFound.js
+++ b/distribution/lib/notFound.js
@@ -9,21 +9,22 @@ var _boom = require('boom');
 
 var _boom2 = _interopRequireDefault(_boom);
 
-var _ResponseHelper = require('./ResponseHelper');
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
  * Return 404 through HTTP response.
  * @private
+ * @param {Object} responseHelper - An instance of ResponseHelper.
  * @param {Object} req - HTTP request.
- * @param {Object} res - HTTP response.
+ * @param {String} req.method - HTTP request Method.
+ * @param {String} req.url - HTTP request url.
  */
-/* eslint import/prefer-default-export: 0 */
-var notFound = exports.notFound = function notFound(req, res) {
-  var responseHelper = new _ResponseHelper.ResponseHelper(req, res, {});
+var notFound = exports.notFound = function notFound(responseHelper, _ref) {
+  var method = _ref.method,
+      url = _ref.url;
+
   responseHelper.handleError({
     statusCode: 404,
-    message: _boom2.default.notFound('Undefined route - ' + req.method + ':' + req.url)
+    message: _boom2.default.notFound('Undefined route - ' + method + ':' + url)
   });
-};
+}; /* eslint import/prefer-default-export: 0 */

--- a/distribution/server/Orchestrator.js
+++ b/distribution/server/Orchestrator.js
@@ -22,6 +22,8 @@ var _notFound = require('../lib/notFound');
 
 var _express3 = require('../dependencies/express');
 
+var _ResponseHelper = require('../lib/ResponseHelper');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -103,6 +105,17 @@ var _initialiseProps = function _initialiseProps() {
           fn = _ref.fn;
       return _this.router[method.toLowerCase()](url, fn);
     });
+
+    routes.forEach(function (_ref2) {
+      var method = _ref2.method,
+          url = _ref2.url,
+          fn = _ref2.fn;
+
+      _this.router[method.toLowerCase()](url, function (req, res) {
+        fn(new _ResponseHelper.ResponseHelper(req, res, _this.config), req, res);
+      });
+    });
+
     _this.app.use(_this.router);
 
     // Must handle errors after settings routes or express throws an error.

--- a/src/lib/ResponseHelper.js
+++ b/src/lib/ResponseHelper.js
@@ -104,20 +104,6 @@ const logRequest = (req, config, options) => {
 }
 
 /**
- * Validate class constructor arguments.
- * @private
- * @param {Object} args - Arguments passed to class constructor.
- * @throws {Error} If an argument is null or undefined.
- */
-const checkArgs = args => {
-  Object.keys(args).forEach((key) => {
-    if (!args[key]) {
-      throw new Error(`new ResponseHelper() - Missing argument ${key}`)
-    }
-  })
-}
-
-/**
  * Handles response standardisation as well as http responses and requests.
  * @class
  * @param {Object} req - {@link https://expressjs.com/en/4x/api.html#req HTTP request}.
@@ -127,7 +113,6 @@ const checkArgs = args => {
  */
 export class ResponseHelper {
   constructor (req, res, config) {
-    checkArgs({ req, res, config })
     this.req = req
     this.res = res
     this.config = config
@@ -144,7 +129,7 @@ export class ResponseHelper {
    * @returns {Promise} Promise object represents server response.
    */
   fetch = (options, retry = true) => new Promise(async (resolve, reject) => {
-    const { body, headers = getHeaders() } = options
+    const { body, headers = getHeaders(), url } = options
     const opt = {
       ...options,
       auth: {
@@ -153,6 +138,7 @@ export class ResponseHelper {
       },
       body: body && typeof body === 'object' ? JSON.stringify(body) : body,
       headers,
+      url: `${this.config.apiUrl}${url}`,
     }
 
     if (!opt.auth.pass) {
@@ -234,7 +220,7 @@ export class ResponseHelper {
    * @param {Object} [options.headers=getHeaders()] - Request headers.
    */
   getFile = async (options) => {
-    const { headers = getHeaders() } = options
+    const { headers = getHeaders(), url } = options
     const opt = {
       ...options,
       auth: {
@@ -242,6 +228,7 @@ export class ResponseHelper {
         pass: this.req.session.cas.pt,
       },
       headers,
+      url: `${this.config.apiUrl}${url}`,
     }
 
     if (!opt.auth.pass) {

--- a/src/lib/ResponseHelper.js
+++ b/src/lib/ResponseHelper.js
@@ -138,7 +138,7 @@ export class ResponseHelper {
       },
       body: body && typeof body === 'object' ? JSON.stringify(body) : body,
       headers,
-      url: `${this.config.apiUrl}${url}`,
+      url: /^.+:\/\//.test(url) ? url : `${this.config.apiUrl}${url}`,
     }
 
     if (!opt.auth.pass) {
@@ -228,7 +228,7 @@ export class ResponseHelper {
         pass: this.req.session.cas.pt,
       },
       headers,
-      url: `${this.config.apiUrl}${url}`,
+      url: /^.+:\/\//.test(url) ? url : `${this.config.apiUrl}${url}`,
     }
 
     if (!opt.auth.pass) {

--- a/src/lib/notFound.js
+++ b/src/lib/notFound.js
@@ -1,17 +1,17 @@
 /* eslint import/prefer-default-export: 0 */
 import boom from 'boom'
-import { ResponseHelper } from './ResponseHelper'
 
 /**
  * Return 404 through HTTP response.
  * @private
+ * @param {Object} responseHelper - An instance of ResponseHelper.
  * @param {Object} req - HTTP request.
- * @param {Object} res - HTTP response.
+ * @param {String} req.method - HTTP request Method.
+ * @param {String} req.url - HTTP request url.
  */
-export const notFound = (req, res) => {
-  const responseHelper = new ResponseHelper(req, res, {})
+export const notFound = (responseHelper, { method, url }) => {
   responseHelper.handleError({
     statusCode: 404,
-    message: boom.notFound(`Undefined route - ${req.method}:${req.url}`),
+    message: boom.notFound(`Undefined route - ${method}:${url}`),
   })
 }

--- a/src/lib/test/ResponseHelperTest.js
+++ b/src/lib/test/ResponseHelperTest.js
@@ -24,6 +24,7 @@ const config = {
   },
   customHeaderPrefix: 'foo',
   log: {},
+  apiUrl: 'https://exemple.com',
 }
 
 describe('server/lib/ResponseHelper', () => {
@@ -66,42 +67,6 @@ describe('server/lib/ResponseHelper', () => {
   })
 
   describe('constructor', () => {
-    it('should throw error if `req` argument is missing', () => {
-      let error = null
-
-      try {
-        new ResponseHelper() // eslint-disable-line no-new
-      } catch (err) {
-        error = err
-      }
-
-      expect(error).to.be.not.null
-    })
-
-    it('should throw error if `res` argument is missing', () => {
-      let error = null
-
-      try {
-        new ResponseHelper(req) // eslint-disable-line no-new
-      } catch (err) {
-        error = err
-      }
-
-      expect(error).to.be.not.null
-    })
-
-    it('should throw error if `config` argument is missing', () => {
-      let error = null
-
-      try {
-        new ResponseHelper(req, res) // eslint-disable-line no-new
-      } catch (err) {
-        error = err
-      }
-
-      expect(error).to.be.not.null
-    })
-
     it('should set it\'s req property correctly', () => {
       const responseHelper = new ResponseHelper(req, res, config)
       expect(responseHelper.req).to.be.equal(req)
@@ -299,10 +264,12 @@ describe('server/lib/ResponseHelper', () => {
           Accept: 'application/json; charset=utf-8',
           'Content-Type': 'application/json; charset=utf-8',
         },
+        url: '/path',
       }
       getProxyTicket.callsFake((targetService, options, cb) => cb(null, 'pt'))
       HTTP.request.get = sinon.spy(() => ({ pipe () {} }))
-      await (new ResponseHelper(req, res, config)).getFile({})
+      await (new ResponseHelper(req, res, config)).getFile(opt)
+      opt.url = `${config.apiUrl}${opt.url}`
       expect(HTTP.request.get).to.be.calledWith(opt)
     })
 

--- a/src/server/Orchestrator.js
+++ b/src/server/Orchestrator.js
@@ -5,6 +5,7 @@ import https from 'https'
 import { configureExpress, handleErrors, setListeners } from './serverConfig'
 import { notFound } from '../lib/notFound'
 import { Router as router } from '../dependencies/express'
+import { ResponseHelper } from '../lib/ResponseHelper'
 
 // Configure http/https before requiring Request module since Request is also using global config
 http.globalAgent.maxSockets = 25
@@ -63,6 +64,13 @@ export default class Orchestrator {
 
     this.router = router()
     routes.forEach(({ method, url, fn }) => this.router[method.toLowerCase()](url, fn))
+
+    routes.forEach(({ method, url, fn }) => {
+      this.router[method.toLowerCase()](url, (req, res) => {
+        fn(new ResponseHelper(req, res, this.config), req, res)
+      })
+    })
+
     this.app.use(this.router)
 
     // Must handle errors after settings routes or express throws an error.


### PR DESCRIPTION
- Les fonctions passées aux routes reçoivent maintenant une instance de ResponseHelper comme premier paramètre
- Il n'est plus nécessaire de déclarer l'URL complète de l'API dans des fonctions des endpoints. ResponseHelper ajoutera le `config.apiUrl` avant de faire la requête si l'url ne commence pas par le schema 'http://'.